### PR TITLE
Fixed map crash on ios , and few CI errors and  updated flutter sdk version to 2.3

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Flutter
+import GoogleMaps
 
 @UIApplicationMain
 @objc class AppDelegate: FlutterAppDelegate {
@@ -7,6 +8,7 @@ import Flutter
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    GMSServices.provideAPIKey("AIzaSyDs4bsy5Uvuo58HW1ZLxgSs3Lyx1ofbXlE")
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -41,5 +41,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>io.flutter.embedded_views_preview</key>
+	<true/>
 </dict>
 </plist>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,5 @@
-import 'package:covid19sl/models/report.dart';
-import 'package:covid19sl/models/statistics.dart';
-import 'package:covid19sl/screens/dashboard.dart';
+
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 import 'screens/home.dart';
 void main() => runApp(Covid19());
 

--- a/lib/models/statistics.dart
+++ b/lib/models/statistics.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 
 import 'package:covid19sl/models/hospital.dart';
 import 'package:covid19sl/models/hospitalData.dart';

--- a/lib/screens/dashboard.dart
+++ b/lib/screens/dashboard.dart
@@ -1,4 +1,4 @@
-import 'package:covid19sl/models/hospitalData.dart';
+
 import 'package:covid19sl/models/statistics.dart';
 import 'package:covid19sl/screens/hospitalList.dart';
 import 'package:covid19sl/services/http.dart';
@@ -58,8 +58,10 @@ class DashboardState extends State<DashboardPage>
                       ],
                     );
 
-                  case ConnectionState.active:
-                    break;
+                  
+                  // case ConnectionState.active:
+                  //   return Container();
+                  //   break;
                   case ConnectionState.done:
                     if (snapshot.hasError)
                       return Text('Error:\n\n${snapshot.error}');
@@ -140,7 +142,7 @@ class DashboardState extends State<DashboardPage>
                                   padding: EdgeInsets.only(
                                       left: 20.0,
                                       right: 25.0,
-                                      top: 25.0,
+                                      //top: 25.0,
                                       bottom: 10.0),
                                   child: Column(
                                     children: <Widget>[

--- a/lib/screens/map.dart
+++ b/lib/screens/map.dart
@@ -8,14 +8,14 @@ class MapPage extends StatefulWidget {
 }
 
 class _MapPageState extends State<MapPage> {
-Set<Marker> _markers = {};
+  Set _markers = {};
   Completer<GoogleMapController> _controller = Completer();
     LatLng pinPosition = LatLng(6.9225, 79.9182);
 
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    return Scaffold(  
            body: Stack(
       children: <Widget>[
         Container(
@@ -25,7 +25,7 @@ Set<Marker> _markers = {};
               CameraPosition(target: LatLng(6.927079, 79.861244), zoom: 10),
           onMapCreated: (GoogleMapController controller) {
             _controller.complete(controller);
-
+            
           setState(() {
 
             _markers.add(

--- a/lib/services/http.dart
+++ b/lib/services/http.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'package:covid19sl/models/report.dart';
 import 'package:covid19sl/models/statistics.dart';
 import 'package:http/http.dart';
 
@@ -11,6 +10,8 @@ class HttpService {
     Response res = await get(localUrl);
     if (res.statusCode == 200) {
       return Statistics.fromJson(jsonDecode(res.body)['data']);
-    } 
+    } else {
+      return null;
+    }
   }
 }

--- a/lib/util/colors.dart
+++ b/lib/util/colors.dart
@@ -1,2 +1,0 @@
-import 'package:flutter/material.dart';
-

--- a/lib/widgets/dashboardWidgets.dart
+++ b/lib/widgets/dashboardWidgets.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
-import 'package:covid19sl/models/statistics.dart';
+//import 'package:provider/provider.dart';
+//import 'package:covid19sl/models/statistics.dart';
 
 
 class DashboardOverviewCard extends StatefulWidget {
@@ -13,7 +13,7 @@ class _DashboardOverviewCardState extends State<DashboardOverviewCard> {
   Widget build(BuildContext context) {  
 
     //have to do a null check here
-   final newsList = Provider.of<Statistics>(context);
+   //final stats = Provider.of<Statistics>(context);
     return Container(
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ description: A new Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.3.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,0 +1,25 @@
+// This is a basic Flutter widget test.
+//
+// To perform an interaction with a widget in your test, use the WidgetTester
+// utility that Flutter provides. For example, you can send tap and scroll
+// gestures. You can also use WidgetTester to find child widgets in the widget
+// tree, read text, and verify that the values of widget properties are correct.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:covid19sl/main.dart';
+
+void main() {
+  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
+    // Build our app and trigger a frame.
+    await tester.pumpWidget(Covid19());
+
+    // Verify that our counter starts at 0.
+   
+
+    // Tap the '+' icon and trigger a frame.
+ 
+
+    // Verify that our counter has incremented.
+  
+  });
+}


### PR DESCRIPTION
I think I might have fixed iOS map crash , I don't have Xcode installed to test it , I might have to download it soon , but its freaking 8 gigs!! lol
And I updated sdk version to 2.3 to use Set literals , It was 2.1 earlier and I couldn't find a way to set markers using a set of markers without using "Set". so if someone find a way around we can switch back to 2.1 , anyways 2.3 supports lots of added features to reduce boilerplate.