### PR TITLE
Added dyamic map marker update via api

### DIFF
--- a/db.json
+++ b/db.json
@@ -4,14 +4,14 @@
     {
       "id": 1,
       "name": "National Institute of Infectious Diseases",
-      "lat": "lat",
-      "long": "long"
+      "lat": "6.9225",
+      "long": "79.9182"
     },
     {
       "id": 2,
-      "name": "National Institute of Infectious Diseases",
-      "lat": "6.9225",
-      "long": "79.9182"
+      "name": "National Hospital Sri Lanka",
+      "lat": "6.917889",
+      "long": "79.8668"
     }
   ]
 }

--- a/db.json
+++ b/db.json
@@ -1,8 +1,6 @@
 {
                     "id": 1,
                     "name": "National Institute of Infectious Diseases",
-                    "name_si": "බෝවන රෝග පිළිබඳ ජාතික ආයතනය",
-                    "name_ta": "தேசிய தொற்று நோயியல் நிறுவனம்",
                     "lat": "6.9225",
                     "long": "79.9182",
 

--- a/db.json
+++ b/db.json
@@ -2,6 +2,6 @@
                     "id": 1,
                     "name": "National Institute of Infectious Diseases",
                     "lat": "6.9225",
-                    "long": "79.9182",
+                    "long": "79.9182"
 
                 }

--- a/db.json
+++ b/db.json
@@ -3,7 +3,7 @@
                     "name": "National Institute of Infectious Diseases",
                     "name_si": "බෝවන රෝග පිළිබඳ ජාතික ආයතනය",
                     "name_ta": "தேசிய தொற்று நோயியல் நிறுவனம்",
-                    "created_at": "2020-03-20 01:54:12",
-                    "updated_at": "2020-03-20 01:54:12",
-                    "deleted_at": null
+                    "lat": "6.9225",
+                    "long": "79.9182",
+
                 }

--- a/db.json
+++ b/db.json
@@ -1,0 +1,9 @@
+{
+                    "id": 1,
+                    "name": "National Institute of Infectious Diseases",
+                    "name_si": "බෝවන රෝග පිළිබඳ ජාතික ආයතනය",
+                    "name_ta": "தேசிய தொற்று நோயியல் நிறுவனம்",
+                    "created_at": "2020-03-20 01:54:12",
+                    "updated_at": "2020-03-20 01:54:12",
+                    "deleted_at": null
+                }

--- a/db.json
+++ b/db.json
@@ -1,7 +1,17 @@
-{
-                    "id": 1,
-                    "name": "National Institute of Infectious Diseases",
-                    "lat": "6.9225",
-                    "long": "79.9182"
 
-                }
+{
+  "marker": [
+    {
+      "id": 1,
+      "name": "National Institute of Infectious Diseases",
+      "lat": "lat",
+      "long": "long"
+    },
+    {
+      "id": 2,
+      "name": "National Institute of Infectious Diseases",
+      "lat": "6.9225",
+      "long": "79.9182"
+    }
+  ]
+}

--- a/db.json
+++ b/db.json
@@ -4,14 +4,14 @@
     {
       "id": 1,
       "name": "National Institute of Infectious Diseases",
-      "lat": "6.9225",
-      "long": "79.9182"
+      "lat": 6.9225,
+      "long": 79.9182
     },
     {
       "id": 2,
       "name": "National Hospital Sri Lanka",
-      "lat": "6.917889",
-      "long": "79.8668"
+      "lat": 6.917889,
+      "long": 79.8668
     }
   ]
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,10 @@
 
 import 'package:flutter/material.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'screens/home.dart';
+import 'package:provider/provider.dart';
+import 'services/http.dart';
+
 void main() => runApp(Covid19());
 
 class Covid19 extends StatelessWidget {
@@ -13,7 +17,11 @@ class Covid19 extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home:Home()
+      home:MultiProvider(
+        providers: [
+          FutureProvider<List<Marker>>.value(value:HttpService().getMarkers() )
+        ],
+        child: Home())
     );
   }
 }

--- a/lib/models/mapMarkers.dart
+++ b/lib/models/mapMarkers.dart
@@ -1,0 +1,13 @@
+/*
+
+JSON Structure
+{
+  "id": 1,
+  "name": "National Institute of Infectious Diseases",
+  "name_si": "බෝවන රෝග පිළිබඳ ජාතික ආයතනය",
+  "name_ta": "தேசிய தொற்று நோயியல் நிறுவனம்",
+  "lat": "",
+  "long": "",
+}
+
+*/

--- a/lib/models/markers.json
+++ b/lib/models/markers.json
@@ -1,0 +1,9 @@
+{
+    "id": 1,
+    "name": "National Institute of Infectious Diseases",
+    "name_si": "බෝවන රෝග පිළිබඳ ජාතික ආයතනය",
+    "name_ta": "தேசிய தொற்று நோயியல் நிறுவனம்",
+    "lat": "6.9225",
+    "long": "79.9182"
+  
+   }

--- a/lib/screens/map.dart
+++ b/lib/screens/map.dart
@@ -1,39 +1,35 @@
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'dart:async';
-
+import 'package:provider/provider.dart';
 class MapPage extends StatefulWidget {
   @override
   _MapPageState createState() => _MapPageState();
 }
 
 class _MapPageState extends State<MapPage> {
-  Set _markers = {};
+  //Set <Marker> _markers = {};
   Completer<GoogleMapController> _controller = Completer();
-    LatLng pinPosition = LatLng(6.9225, 79.9182);
+  LatLng pinPosition = LatLng(6.9225, 79.9182);
 
 
   @override
   Widget build(BuildContext context) {
+
+    List<Marker> markers = Provider.of<List<Marker>>(context);
+
     return Scaffold(  
            body: Stack(
       children: <Widget>[
         Container(
             child: GoogleMap(
-              markers: _markers,
+              markers: Set.from(markers),
           initialCameraPosition:
               CameraPosition(target: LatLng(6.927079, 79.861244), zoom: 10),
-          onMapCreated: (GoogleMapController controller) {
+          onMapCreated: (GoogleMapController controller) async {
             _controller.complete(controller);
             
           setState(() {
-
-            _markers.add(
-            Marker(
-               markerId: MarkerId('test'),
-               infoWindow: InfoWindow(title: "IDH Hospital"),
-               position: pinPosition,
-            ));
             
           });
 
@@ -46,3 +42,4 @@ class _MapPageState extends State<MapPage> {
     );
   }
 }
+

--- a/lib/services/http.dart
+++ b/lib/services/http.dart
@@ -1,10 +1,14 @@
 import 'dart:convert';
 import 'package:covid19sl/models/statistics.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:http/http.dart';
 
 class HttpService {
   final String localUrl =
       "http://hpb.health.gov.lk/api/get-current-statistical";
+
+  final String markersUrl =
+      "http://my-json-server.typicode.com/yasaswick/covid19sl-mobile/marker";
 
   Future<Statistics> getData() async {
     Response res = await get(localUrl);
@@ -12,6 +16,27 @@ class HttpService {
       return Statistics.fromJson(jsonDecode(res.body)['data']);
     } else {
       return null;
+    }
+  }
+
+  Future<List<Marker>> getMarkers() async {
+    List<Marker> markerList;
+
+    Response res = await get(markersUrl);
+    if (res.statusCode == 200) {
+      List<dynamic> parsedJson = jsonDecode(res.body);
+
+      print(parsedJson);
+
+      markerList = parsedJson.map((i) {
+        return Marker(
+          infoWindow: InfoWindow(title: i['name']),
+            markerId: MarkerId(i['name']),
+            position: LatLng(i['lat'], i['long']));
+      }).toList();
+      return markerList;
+    } else {
+      return markerList;
     }
   }
 }


### PR DESCRIPTION
1.db.json have markers and https://jsonplaceholder.typicode.com uses db.json to create a api endpoint at "http://my-json-server.typicode.com/yasaswick/covid19sl-mobile/marker" , please change this to ""http://my-json-server.typicode.com/sliit-foss/covid19sl-mobile/marker" after merging . and shall I open a issue for someone to contribute to manually add lat longs to the db.json ?

2.jsonplaceholder.typicode.com only allows to mock 4 fields , so might have to update json structure to support add other languages later.
maps.dart uses a FutureProvider , so it has a glitch while the List of Markers are being created.

![dd04fd2d-090f-4f59-b246-7d15cb926dd6](https://user-images.githubusercontent.com/61660117/77449988-ada89b00-6e18-11ea-9d9c-dbeccdd66c4c.JPG)
